### PR TITLE
fix: missing '}' in main.json dashboard

### DIFF
--- a/grafana/provisioning/dashboards/main.json
+++ b/grafana/provisioning/dashboards/main.json
@@ -507,6 +507,7 @@
                 "none"
               ],
               "type": "time"
+            }
           ],
           "metricColumn": "none",
           "rawQuery": true,


### PR DESCRIPTION
Found while following the README and importing dashboards.