### PR TITLE
feat(dashboard): Add top_miners_by_base_reward dashboard

### DIFF
--- a/grafana/provisioning/dashboards/top_miner_block_reward.json
+++ b/grafana/provisioning/dashboards/top_miner_block_reward.json
@@ -1,0 +1,125 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "panels": [
+    {
+      "columns": [],
+      "datasource": null,
+      "description": "All accumulated rewards for miners updated each day at midnight.",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 13,
+        "w": 11,
+        "x": 7,
+        "y": 0
+      },
+      "id": 2,
+      "pageSize": 50,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": false
+      },
+      "styles": [
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "total_reward",
+          "thresholds": [],
+          "type": "number",
+          "unit": "sci"
+        }
+      ],
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  rank AS \"Rank\",\n  miner AS \"Miner\",\n  total_reward/(10^18) AS \"Total Reward\"\nFROM top_miners_by_base_reward\nORDER BY 1 ASC",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Top Miners by Block Reward",
+      "transform": "table",
+      "transparent": true,
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 22,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Top Miners by Block Reward",
+  "uid": "P_Q13JnMz",
+  "variables": {
+    "list": []
+  },
+  "version": 1
+}


### PR DESCRIPTION
Part of https://github.com/filecoin-project/sentinel/issues/26

Include dashboard which exposes the Top Miners by Base Reward.
![TopMinersByBaseReward](https://user-images.githubusercontent.com/305332/87975741-040da980-ca9a-11ea-8091-12c25661d9aa.png)
