### PR TITLE
refactor: stop prometheus from polling lotus

### DIFF
--- a/scripts/telegraf.conf.default
+++ b/scripts/telegraf.conf.default
@@ -165,9 +165,12 @@
   lotus_datapath = "${HOME}/.lotus"
 
 [[inputs.prometheus]]
-  urls = [
-    "http://localhost:1234/debug/metrics", # lotus daemon
-  ]
+   urls = [
+      "http://localhost:1234/debug/metrics", # lotus daemon
+    ]
+    namedrop = [
+      "lotus_info",
+    ]
 
 [[inputs.kernel]] # Get kernel statistics from /proc/stat
   ## no configuration


### PR DESCRIPTION
Makes progress towards: filecoin-project/sentinel#34
metric gathering replaced via https://github.com/filecoin-shipyard/telegraf-lotus/pull/12

Once this PR and https://github.com/filecoin-shipyard/telegraf-lotus/pull/12 have merged filecoin-project/sentinel#34 may be closed.