### PR TITLE
fix(telegraf): Use lotus_api_token for lotus_peer_id processor

### DIFF
--- a/scripts/telegraf.conf.default
+++ b/scripts/telegraf.conf.default
@@ -147,7 +147,7 @@
 ###############################################################################
 [[processors.lotus_peer_id]]
   lotus_api_multiaddr = "{{ lotus_api_multiaddr }}"
-  lotus_datapath = "{{ lotus_path }}"
+  lotus_api_token = "{{ lotus_jwt_token }}"
 
 
 ###############################################################################


### PR DESCRIPTION
The processor needs to use the token instead of the path to the lotus repo.