### PR TITLE
change the prometheus->telegraf metrics mapping

### DIFF
--- a/scripts/telegraf.conf.default
+++ b/scripts/telegraf.conf.default
@@ -174,6 +174,7 @@
   # lotus_datapath = ""
 
 [[inputs.prometheus]]
+  metric_version = 2
   urls = [
     "{{ lotus_prometheus_url }}", # lotus daemon
    ]


### PR DESCRIPTION
This updates the metric_version of the prometheus input to version 2, which brings the telegraf mapping more inline with how prometheus natively outputs metrics, especially histograms and summaries.

So for a prometheus metric that displays like the following, on the prometheus endpoint:
```
http_request_duration_seconds_bucket{le="0.05"} 24054
http_request_duration_seconds_bucket{le="0.1"} 33444
http_request_duration_seconds_bucket{le="0.2"} 100392
http_request_duration_seconds_bucket{le="0.5"} 129389
http_request_duration_seconds_bucket{le="1"} 133988
http_request_duration_seconds_bucket{le="+Inf"} 144320
http_request_duration_seconds_sum 53423
http_request_duration_seconds_count 144320
```

Which is currently converted to the following by telegraf
```
http_request_duration_seconds sum=53423,0.05=24054,0.1=33444,0.2=100392,0.5=129389,1=133988,+Inf=144320,count=144320
```

Will become the following instead
```
prometheus,le=0.05 http_request_duration_seconds_bucket=24054
prometheus,le=0.1 http_request_duration_seconds_bucket=33444
prometheus,le=0.2 http_request_duration_seconds_bucket=100392
prometheus,le=0.5 http_request_duration_seconds_bucket=129389
prometheus,le=1.0 http_request_duration_seconds_bucket=133988
prometheus,le=+Inf http_request_duration_seconds_bucket=144320
```

See https://github.com/influxdata/telegraf/issues/4415 for more information.

TODO:
- [x] check the impact on the database schema for the impacted tables, i.e. `lotus_block_validation_ms`

So this change entirely changes how the telegraf metrics are represented in postgres. @placer14 it ends up being exactly how I was suggesting I would want prometheus metrics to be in postgres, the tables in a table thing. Schema-wise, you end up with a single table of prometheus metrics that contain all metrics and labels as fields. Looking at the table as a whole is rather confusing but it makes queries much simpler, kind of. In a different way...

![prometheus](https://user-images.githubusercontent.com/5924712/92070419-4cd1b580-edef-11ea-95b4-3fd0737c62e2.png)
