### PR TITLE
docs: add architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Sentinel is a collection of services which monitor the health and function of th
 
 The metrics are pushed to TimescaleDB from Telegraf-based remote-host agents and a centralized data processing pipeline. [Lotus](https://github.com/filecoin-project/lotus/) is attached to the processing pipeline as a source of truth for immutable network state.
 
+![sentinel architecture diagram](https://user-images.githubusercontent.com/58871/92404078-a48f5a00-f12a-11ea-8987-8b5a42091ad2.png)
 
 ## Setup
 


### PR DESCRIPTION
adds a high level overview diagram to show how the pieces of sentinel fit together

fixes: #115

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>