### PR TITLE
feat: provision grafana datasource and dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,37 +25,15 @@ _TODO: Add missing build dep installation steps._
 5. `make run-docker` to start Docker services
 6. (In separate windows) `make run-telegraf` and `make run-chainwatch`.
 
-### Configure Grafana Datasource
+### Configure Grafana
 
-Note: This process will eventually be automatically provisioned on startup.
+1. Visit [http://localhost:3000](http://localhost:3000) to open Grafana.
+2. Login with username and password as `admin`. Change the admin password.
 
-7. Visit [http://localhost:3000](http://localhost:3000) to open Grafana.
-8. Login with username and password as `admin`. Change the admin password.
-9. Follow prompt to setup a PostgreSQL Datasource with the following setttings:
+The datasource and dashboards are provisioned by the config in 
 
-#### PostgreSQL Connection
-
-- Name (optional): `TimescaleDB`
-- Host: `timescaledb:5432`
-- Database: `postgres`
-- User: `postgres`
-- Password: `password`
-- SSL Mode: `disabled`
-
-#### PostgreSQL details
-
-- Version: `10`
-- TimescaleDB: `true`
-- Min Time Interval: `1s`
-
-10. Click Save and Test.
-
-### Configure Grafana Dashboards
-
-11. Return to Home and follow prompt to add new dashboards. Find the Import option in the top right of the screen.
-12. Upload the desired dashboard JSON from the available dashboard payloads found in [grafana/provisioning/dashboards/](https://github.com/filecoin-project/sentinel/tree/master/grafana/provisioning/dashboards).
-13. Click Import (or if you already have the dashboard imported with this name, select Overwrite).
-
+- `grafana/provisioning/dashboards/dashboards.yml`
+- `grafana/provisioning/datasources/timescaledb.yml`
 
 ## Managing Sentinel
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - timescaledb
     volumes:
       - grafana-data:/var/lib/grafana/
+      - ./grafana/provisioning:/etc/grafana/provisioning
+
     environment:
       GF_RENDERING_SERVER_URL: http://renderer:8081/render
       GF_RENDERING_CALLBACK_URL: http://grafana:3000/

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,26 @@
+apiVersion: 1
+
+providers:
+  # <string> an unique provider name. Required
+  - name: 'sentinel'
+    # <int> Org id. Default to 1
+    orgId: 1
+    # <string> name of the dashboard folder.
+    folder: 'sentinel'
+    # <string> folder UID. will be automatically generated if not specified
+    folderUid: 'sentinel'
+    # <string> provider type. Default to 'file'
+    type: file
+    # <bool> disable dashboard deletion
+    disableDeletion: false
+    # <bool> enable dashboard editing
+    editable: true
+    # <int> how often Grafana will scan for changed dashboards
+    updateIntervalSeconds: 10
+    # <bool> allow updating provisioned dashboards from the UI
+    allowUiUpdates: true
+    options:
+      # <string, required> path to dashboard files on disk. Required when using the 'file' type
+      path: /etc/grafana/provisioning/dashboards
+      # <bool> use folder names from filesystem to create folders in Grafana
+      foldersFromFilesStructure: false

--- a/grafana/provisioning/datasources/timescaledb.yml
+++ b/grafana/provisioning/datasources/timescaledb.yml
@@ -1,0 +1,46 @@
+# config file version
+apiVersion: 1
+
+# list of datasources that should be deleted from the database
+deleteDatasources:
+  - name: TimescaleDB
+    orgId: 1
+
+# list of datasources to insert/update depending
+# what's available in the database
+datasources:
+  # <string, required> name of the datasource. Required
+  - name: TimescaleDB
+    # <string, required> datasource type. Required
+    type: postgres
+    # <string, required> access mode. proxy or direct (Server or Browser in the UI). Required
+    access: proxy
+    # <int> org id. will default to orgId 1 if not specified
+    orgId: 1
+    # <string> custom UID which can be used to reference this datasource in other parts of the configuration, if not specified will be generated automatically
+    uid: timescaledb
+    # <string> url
+    url: timescaledb:5432
+    # <string> database user, if used
+    user: postgres
+    # <string> database name, if used
+    database: postgres
+    # <bool> enable/disable basic auth
+    basicAuth: false
+    # <bool> mark as default datasource. Max one per org
+    isDefault: true
+    # <map> fields that will be converted to json and stored in jsonData
+    jsonData:
+      postgresVersion: 1000
+      sslmode: disable
+      timeInterval: "1s"
+      timescaledb: true
+    # <string> json object of data that will be encrypted.
+    secureJsonData:
+      # <string> database password, if used
+      password: password
+
+    # <bool> allow users to edit datasources from the UI.
+    editable: false
+    readOnly: true
+    version: 1


### PR DESCRIPTION
Automates provisioning of datasource and dashboards by following along with the docs in https://grafana.com/docs/grafana/latest/administration/provisioning/

With this you should be able to run `make run-docker` and get a grafana that is already wired up with the TimescaleDB datasource set as the default and the current dashboards in a sentinel folder.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>