### PR TITLE
feat(dashboard): Update dashboards for Grafana 7.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
 
   grafana:
     container_name: grafana
-    image: grafana/grafana:latest
+    image: grafana/grafana:7.1.5-ubuntu
     ports:
       - "3000:3000"
     links:
@@ -27,7 +27,7 @@ services:
       GF_LOG_FILTERS: rendering:debug
 
   renderer:
-    image: grafana/grafana-image-renderer:latest
+    image: grafana/grafana-image-renderer:2.0.0
     ports:
       - 8081
 

--- a/grafana/provisioning/dashboards/main.json
+++ b/grafana/provisioning/dashboards/main.json
@@ -14,26 +14,439 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
-  "id": 1,
+  "graphTooltip": 2,
+  "id": 4,
   "links": [],
   "panels": [
     {
-      "content": "# Chain State",
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 0,
       "gridPos": {
-        "h": 2,
-        "w": 24,
+        "h": 4,
+        "w": 6,
         "x": 0,
         "y": 0
       },
-      "id": 15,
-      "mode": "markdown",
+      "hiddenSeries": false,
+      "id": 22,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "hideEmpty": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": false,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pluginVersion": "7.1.5",
+      "pointradius": 0.5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Failure",
+          "color": "#E02F44"
+        },
+        {
+          "alias": "Success",
+          "color": "#96D98D"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": false,
+          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  counter - lag(counter) OVER (ORDER BY \"time\") AS \"Failure\"\nFROM lotus_message_failure\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "counter"
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "delta"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "Failure"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "table": "lotus_message_failure",
+          "timeColumn": "\"time\"",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": false,
+          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  counter - lag(counter) OVER (ORDER BY \"time\") AS \"Success\"\nFROM lotus_message_success\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1",
+          "refId": "B",
+          "select": [
+            [
+              {
+                "params": [
+                  "counter"
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "delta"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "Success"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "table": "lotus_message_success",
+          "timeColumn": "\"time\"",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Messages Recieved",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Number of peers connected to the lotus node.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  gauge\nFROM lotus_peer_count\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "gauge"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "lotus_peer_count",
+          "timeColumn": "\"time\"",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Connected Peers Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "description": "Total Tipsets/Blocks on Chain",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  NOW() AS \"time\",\n  count(*) AS \"Blocks\"\nFROM \"blocks\"",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "pledged_collateral"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "\"chain.economics\"",
+          "timeColumn": "\"time\"",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  NOW() AS \"time\",\n  max(height) AS \"Tipsets\"\nFROM \"blocks\"",
+          "refId": "B",
+          "select": [
+            [
+              {
+                "params": [
+                  "counter"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "lotus_rpc_response_error",
+          "timeColumn": "\"time\"",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  NOW() AS \"time\",\n  count(cid)::float/max(height)::float AS \"Block/Tipset Ratio\"\nFROM \"blocks\"",
+          "refId": "C",
+          "select": [
+            [
+              {
+                "params": [
+                  "counter"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "lotus_rpc_response_error",
+          "timeColumn": "\"time\"",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
       "timeFrom": null,
       "timeShift": null,
       "title": "",
-      "transparent": true,
-      "type": "text"
+      "type": "stat"
     },
     {
       "alert": {
@@ -50,18 +463,18 @@
             "query": {
               "params": [
                 "A",
-                "5m",
+                "1m",
                 "now"
               ]
             },
             "reducer": {
               "params": [],
-              "type": "count"
+              "type": "last"
             },
             "type": "query"
           }
         ],
-        "executionErrorState": "alerting",
+        "executionErrorState": "keep_state",
         "for": "2m",
         "frequency": "1m",
         "handler": 1,
@@ -78,25 +491,32 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TimescaleDB",
       "decimals": 0,
       "description": "Number of blocks reported by network by Miner ID.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 20,
         "x": 0,
-        "y": 2
+        "y": 4
       },
       "hiddenSeries": false,
       "id": 2,
-      "interval": "5s",
+      "interval": "30s",
       "legend": {
         "alignAsTable": true,
         "avg": false,
         "current": false,
-        "hideZero": false,
+        "hideZero": true,
         "max": false,
         "min": false,
         "rightSide": true,
@@ -109,10 +529,8 @@
       "lines": false,
       "linewidth": 1,
       "nullPointMode": "null as zero",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -185,7 +603,7 @@
               }
             ]
           ],
-          "table": "\"chain_block\"",
+          "table": "\"chain.block\"",
           "timeColumn": "\"time\"",
           "timeColumnType": "timestamp",
           "where": [
@@ -241,44 +659,49 @@
     {
       "datasource": null,
       "description": "Time elapsed since last block found.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 5,
         "w": 4,
         "x": 20,
-        "y": 2
+        "y": 4
       },
       "id": 4,
       "options": {
         "colorMode": "value",
-        "fieldOptions": {
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
           "calcs": [
             "lastNotNull"
           ],
-          "defaults": {
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 30
-                }
-              ]
-            },
-            "unit": "s"
-          },
-          "overrides": [],
+          "fields": "",
           "values": false
         },
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto"
+        "textMode": "auto"
       },
-      "pluginVersion": "6.7.3",
+      "pluginVersion": "7.1.5",
       "targets": [
         {
           "format": "time_series",
@@ -297,7 +720,7 @@
               }
             ]
           ],
-          "table": "\"chain_economics\"",
+          "table": "\"chain.economics\"",
           "timeColumn": "\"time\"",
           "timeColumnType": "timestamp",
           "where": [
@@ -315,133 +738,95 @@
       "type": "stat"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
+      "cards": {
+        "cardPadding": 0,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#96D98D",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGreens",
+        "exponent": 0.8,
+        "max": null,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
       "datasource": null,
-      "description": "Average message size (within minimum/maximum band).",
-      "fill": 0,
-      "fillGradient": 0,
+      "description": "Duration reported by lotus between receipt and validation of a block.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "gridPos": {
-        "h": 5,
-        "w": 16,
+        "h": 10,
+        "w": 17,
         "x": 0,
-        "y": 7
+        "y": 9
       },
-      "hiddenSeries": false,
-      "id": 8,
-      "interval": "1s",
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 20,
+      "interval": "30s",
       "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
+        "show": true
       },
-      "lines": true,
-      "linewidth": 2,
-      "nullPointMode": "null as zero",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "Maximum",
-          "fillBelowTo": "Minimum",
-          "lines": false
-        },
-        {
-          "alias": "Average",
-          "color": "rgb(223, 239, 255)"
-        },
-        {
-          "alias": "Minimum",
-          "lines": false
-        },
-        {
-          "alias": "Count",
-          "yaxis": 2
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "reverseYBuckets": false,
       "targets": [
-        {
-          "format": "time_series",
-          "group": [
-            {
-              "params": [
-                "$__interval",
-                "none"
-              ],
-              "type": "time"
-            }
-          ],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(\"time\",$__interval),\n  min(message_size) AS \"Minimum\",\n  avg(message_size) AS \"Average\",\n  max(message_size) AS \"Maximum\"\nFROM \"chain_messages\"\nWHERE\n  $__timeFilter(\"time\")\nGROUP BY 1\nORDER BY 1",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "pledged_collateral"
-                ],
-                "type": "column"
-              },
-              {
-                "params": [
-                  "avg"
-                ],
-                "type": "aggregate"
-              },
-              {
-                "params": [
-                  "pledged_collateral"
-                ],
-                "type": "alias"
-              }
-            ]
-          ],
-          "table": "\"chain_economics\"",
-          "timeColumn": "\"time\"",
-          "timeColumnType": "timestamp",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        },
         {
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(\"time\",$__interval),\n  count(message_size) AS \"Count\"\nFROM \"chain_messages\"\nWHERE\n  $__timeFilter(\"time\")\nGROUP BY 1\nORDER BY 1",
-          "refId": "B",
+          "rawSql": "SELECT\n  \"time\",\n  -- \"0.01\" - LAG(\"0.01\") OVER (ORDER BY \"time\") AS \"0.01\",\n  -- \"0.05\" - LAG(\"0.05\") OVER (ORDER BY \"time\") AS \"0.05\",\n  -- \"0.1\" - LAG(\"0.1\") OVER (ORDER BY \"time\") AS \"0.1\",\n  -- \"0.3\" - LAG(\"0.3\") OVER (ORDER BY \"time\") AS \"0.3\",\n  -- \"0.6\" - LAG(\"0.6\") OVER (ORDER BY \"time\") AS \"0.6\",\n  -- \"0.8\" - LAG(\"0.8\") OVER (ORDER BY \"time\") AS \"0.8\",\n  -- \"1\" - LAG(\"1\") OVER (ORDER BY \"time\") AS \"1\",\n  -- \"2\" - LAG(\"2\") OVER (ORDER BY \"time\") AS \"2\",\n  -- \"3\" - LAG(\"3\") OVER (ORDER BY \"time\") AS \"3\",\n  -- \"4\" - LAG(\"4\") OVER (ORDER BY \"time\") AS \"4\",\n  -- \"5\" - LAG(\"5\") OVER (ORDER BY \"time\") AS \"5\",\n  -- \"6\" - LAG(\"6\") OVER (ORDER BY \"time\") AS \"6\",\n  -- \"8\" - LAG(\"8\") OVER (ORDER BY \"time\") AS \"8\",\n  -- \"10\" - LAG(\"10\") OVER (ORDER BY \"time\") AS \"10\",\n  -- \"13\" - LAG(\"13\") OVER (ORDER BY \"time\") AS \"13\",\n  -- \"16\" - LAG(\"16\") OVER (ORDER BY \"time\") AS \"16\",\n  \"20\" - LAG(\"20\") OVER (ORDER BY \"time\") AS \"20\",\n  \"25\" - LAG(\"25\") OVER (ORDER BY \"time\") AS \"25\",\n  \"30\" - LAG(\"30\") OVER (ORDER BY \"time\") AS \"30\",\n  \"40\" - LAG(\"40\") OVER (ORDER BY \"time\") AS \"40\",\n  \"50\" - LAG(\"50\") OVER (ORDER BY \"time\") AS \"50\",\n  \"65\" - LAG(\"65\") OVER (ORDER BY \"time\") AS \"65\",\n  \"80\" - LAG(\"80\") OVER (ORDER BY \"time\") AS \"80\",\n  \"100\" - LAG(\"100\") OVER (ORDER BY \"time\") AS \"100\",\n  \"130\" - LAG(\"130\") OVER (ORDER BY \"time\") AS \"130\",\n  \"160\" - LAG(\"160\") OVER (ORDER BY \"time\") AS \"160\",\n  \"200\" - LAG(\"200\") OVER (ORDER BY \"time\") AS \"200\",\n  \"250\" - LAG(\"250\") OVER (ORDER BY \"time\") AS \"250\",\n  \"300\" - LAG(\"300\") OVER (ORDER BY \"time\") AS \"300\",\n  \"400\" - LAG(\"400\") OVER (ORDER BY \"time\") AS \"400\",\n  \"500\" - LAG(\"500\") OVER (ORDER BY \"time\") AS \"500\",\n  \"650\" - LAG(\"650\") OVER (ORDER BY \"time\") AS \"650\",\n  \"800\" - LAG(\"800\") OVER (ORDER BY \"time\") AS \"800\",\n  \"1000\" - LAG(\"1000\") OVER (ORDER BY \"time\") AS \"1000\",\n  \"2000\" - LAG(\"2000\") OVER (ORDER BY \"time\") AS \"2000\",\n  \"5000\" - LAG(\"5000\") OVER (ORDER BY \"time\") AS \"5000\",\n  \"10000\" - LAG(\"10000\") OVER (ORDER BY \"time\") AS \"10000\",\n  \"20000\" - LAG(\"20000\") OVER (ORDER BY \"time\") AS \"20000\",\n  \"50000\" - LAG(\"50000\") OVER (ORDER BY \"time\") AS \"50000\",\n  \"100000\" - LAG(\"100000\") OVER (ORDER BY \"time\") AS \"100000\"\nFROM lotus_block_validation_ms\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1",
+          "refId": "A",
           "select": [
             [
               {
                 "params": [
-                  "pledged_collateral"
+                  "\"0.1\""
                 ],
                 "type": "column"
+              },
+              {
+                "params": [
+                  "delta"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "0.01"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "\"0.3\""
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "delta"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "0.05"
+                ],
+                "type": "alias"
               }
             ]
           ],
-          "table": "\"chain_economics\"",
+          "table": "lotus_block_validation_ms",
           "timeColumn": "\"time\"",
-          "timeColumnType": "timestamp",
+          "timeColumnType": "timestamptz",
           "where": [
             {
               "name": "$__timeFilter",
@@ -451,47 +836,32 @@
           ]
         }
       ],
-      "thresholds": [],
       "timeFrom": null,
-      "timeRegions": [],
       "timeShift": null,
-      "title": "Avg Message Size",
+      "title": "Block Validation Time",
       "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
         "show": true,
-        "values": []
+        "showHistogram": true
       },
-      "yaxes": [
-        {
-          "decimals": 0,
-          "format": "decbytes",
-          "label": "bytes",
-          "logBase": 10,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": "count",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "tooltipDecimals": 0,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": 60,
+      "xBucketSize": "",
+      "yAxis": {
+        "decimals": null,
+        "format": "ms",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "lower",
+      "yBucketNumber": 24,
+      "yBucketSize": null
     },
     {
       "aliasColors": {},
@@ -499,18 +869,25 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Total message size found per 30 minute interval.",
+      "description": "Total message size found.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 5,
       "fillGradient": 0,
       "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 16,
-        "y": 7
+        "h": 5,
+        "w": 7,
+        "x": 17,
+        "y": 9
       },
       "hiddenSeries": false,
       "id": 25,
-      "interval": "30m",
+      "interval": "45m",
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -525,10 +902,8 @@
       "lines": false,
       "linewidth": 1,
       "nullPointMode": "null as zero",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -550,7 +925,7 @@
           ],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(\"time\",$__interval),\n  count(message_size) AS \"Total\"\nFROM \"chain_messages\"\nWHERE\n  $__timeFilter(\"time\")\nGROUP BY 1\nORDER BY 1",
+          "rawSql": "WITH message_per_epoch AS (\n\tSELECT\n\t  to_timestamp(\"b\".\"timestamp\") AS \"time\",\n\t  count(*) AS \"total\"\n\tFROM \"messages\" m\n\tJOIN \"block_messages\" bm ON m.cid = bm.message\n\tJOIN \"blocks\" b ON bm.block = b.cid\n\tWHERE\n\t   $__unixEpochFilter(\"b\".\"timestamp\")\n\tGROUP BY 1\n\tORDER BY 1\n)\nSELECT\n  $__timeGroupAlias(\"time\",'30s'),\n  total AS \"Total Messages\"\nFROM message_per_epoch\nWHERE\n  $__timeFilter(\"time\")\n",
           "refId": "A",
           "select": [
             [
@@ -574,7 +949,7 @@
               }
             ]
           ],
-          "table": "\"chain_economics\"",
+          "table": "\"chain.economics\"",
           "timeColumn": "\"time\"",
           "timeColumnType": "timestamp",
           "where": [
@@ -590,7 +965,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Total Messages per 30 minutes",
+      "title": "Total Messages",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -634,40 +1009,57 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Total message size found on-chain.",
-      "fill": 5,
+      "description": "Shows message sizes as each message is included on-chain.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
       "fillGradient": 0,
       "gridPos": {
-        "h": 6,
-        "w": 16,
-        "x": 0,
-        "y": 12
+        "h": 5,
+        "w": 7,
+        "x": 17,
+        "y": 14
       },
       "hiddenSeries": false,
-      "id": 9,
-      "interval": "1s",
+      "id": 8,
+      "interval": "30s",
       "legend": {
-        "alignAsTable": true,
-        "avg": true,
+        "avg": false,
         "current": false,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": true,
-        "values": true
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 2,
       "nullPointMode": "null as zero",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "Maximum",
+          "fillBelowTo": "Minimum",
+          "lines": false
+        },
+        {
+          "alias": "Average",
+          "color": "rgb(223, 239, 255)"
+        },
+        {
+          "alias": "Minimum",
+          "lines": false
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -685,7 +1077,7 @@
           ],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(\"time\",$__interval),\n  sum(message_size) AS \"Total\"\nFROM \"chain_messages\"\nWHERE\n  $__timeFilter(\"time\")\nGROUP BY 1\nORDER BY 1",
+          "rawSql": "WITH message_sizes AS (\n\tSELECT \n\t\tto_timestamp(b.timestamp) AS \"time\",\n\t\tm.size_bytes AS \"message_bytes\"\n\tFROM \"messages\" m\n\tJOIN \"block_messages\" bm ON m.cid = bm.message\n\tJOIN \"blocks\" b ON b.cid = bm.block\n\tWHERE\n\t  $__unixEpochFilter(\"b\".\"timestamp\")\n)\nSELECT\n  $__timeGroupAlias(\"message_sizes\".\"time\",$__interval),\n  min(message_bytes) AS \"Minimum\",\n  avg(message_bytes) AS \"Average\",\n  max(message_bytes) AS \"Maximum\",\n  sum(message_bytes) AS \"Sum\"\nFROM \"message_sizes\"\nGROUP BY 1\nORDER BY 1;",
           "refId": "A",
           "select": [
             [
@@ -709,7 +1101,7 @@
               }
             ]
           ],
-          "table": "\"chain_economics\"",
+          "table": "\"chain.economics\"",
           "timeColumn": "\"time\"",
           "timeColumnType": "timestamp",
           "where": [
@@ -725,7 +1117,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Total Message Size",
+      "title": "Message Size",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -744,14 +1136,14 @@
           "decimals": 0,
           "format": "decbytes",
           "label": "bytes",
-          "logBase": 1,
+          "logBase": 10,
           "max": null,
           "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
+          "label": "count",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -769,81 +1161,67 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Size of block headers.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 8,
-        "x": 16,
-        "y": 13
+        "w": 24,
+        "x": 0,
+        "y": 19
       },
       "hiddenSeries": false,
-      "id": 13,
+      "id": 27,
       "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": true,
-        "min": true,
-        "rightSide": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
         "show": true,
-        "total": true,
-        "values": true
+        "total": false,
+        "values": false
       },
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "miner_count",
+          "yaxis": 2
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
           "format": "time_series",
-          "group": [
-            {
-              "params": [
-                "$__interval",
-                "none"
-              ],
-              "type": "time"
-            }
-          ],
+          "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(\"time\",$__interval),\n  avg(header_size) AS \"header_size\"\nFROM \"chain_block\"\nWHERE\n  $__timeFilter(\"time\")\nGROUP BY 1\nORDER BY 1",
+          "rawSql": "-- total network power over time\nwith epoch as (\n    select distinct on (height)\n        time_bucket('30s', to_timestamp(blocks.timestamp)) as \"time\",\n        --$__timeGroup(blocks.timestamp, '1h'),\n        spi.state_root\n    from blocks\n    join sector_precommit_info spi on height = spi.precommit_epoch\n    where to_timestamp(blocks.timestamp) > $__timeFrom()\n    AND to_timestamp(blocks.timestamp) < $__timeTo()\n    group by blocks.timestamp, spi.state_root, height\n    order by height, time desc\n)\nselect\n    epoch.time,\n    miner_count,\n    total_raw_bytes_power::numeric,\n    total_qa_bytes_power::numeric\nfrom chain_power\njoin epoch on epoch.state_root = chain_power.state_root\norder by time desc;",
           "refId": "A",
           "select": [
             [
               {
                 "params": [
-                  "header_size"
+                  "counter"
                 ],
                 "type": "column"
-              },
-              {
-                "params": [
-                  "avg"
-                ],
-                "type": "aggregate"
-              },
-              {
-                "params": [
-                  "header_size"
-                ],
-                "type": "alias"
               }
             ]
           ],
-          "table": "\"chain_block\"",
+          "table": "lotus_block_failure",
           "timeColumn": "\"time\"",
           "timeColumnType": "timestamp",
           "where": [
@@ -859,7 +1237,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Block Header Size",
+      "title": "Total Network Power over Time",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -876,7 +1254,7 @@
       "yaxes": [
         {
           "format": "decbytes",
-          "label": "bytes",
+          "label": null,
           "logBase": 1,
           "max": null,
           "min": null,
@@ -904,13 +1282,20 @@
       "datasource": null,
       "decimals": 0,
       "description": "Number of actor messages executed grouped by exit code.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 16,
+        "h": 7,
+        "w": 24,
         "x": 0,
-        "y": 18
+        "y": 24
       },
       "hiddenSeries": false,
       "id": 11,
@@ -931,10 +1316,8 @@
       "lines": false,
       "linewidth": 1,
       "nullPointMode": "null as zero",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -954,9 +1337,10 @@
               "type": "time"
             }
           ],
+          "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(\"time\",$__interval, 0),\n  CONCAT(actor,'/',method,' -> ',exitcode) AS \"metric\",\n  sum(count) AS \"count\"\nFROM \"chain_actors\"\nWHERE\n  $__timeFilter(\"time\")\nGROUP BY 1, 2\nORDER BY 1, 2",
+          "rawSql": "WITH actor_results as (\n\tSELECT\n\t\ttime_bucket('30s', to_timestamp(\"b\".\"timestamp\")) AS \"time\",\n\t\tconcat(a.code,'/',m.method,' -> ',r.exit) AS \"msg\"\n\tFROM \"receipts\" r\n\tJOIN \"messages\" m ON r.msg = m.cid\n\tJOIN \"block_messages\" bm ON m.cid = bm.message\n\tJOIN \"blocks\" b ON bm.block = b.cid\n\tJOIN \"actors\" a ON r.state = a.stateroot AND m.to = a.id\n  WHERE\n    $__unixEpochFilter(\"b\".\"timestamp\")\n\tORDER BY b.height DESC\n) SELECT\n\t$__timeGroupAlias(\"time\",$__interval, 0),\n\tmsg,\n\tcount(msg)\nFROM actor_results\nGROUP BY 1, 2\nORDER BY 1, 2",
           "refId": "A",
           "select": [
             [
@@ -980,7 +1364,7 @@
               }
             ]
           ],
-          "table": "\"chain_economics\"",
+          "table": "\"chain.economics\"",
           "timeColumn": "\"time\"",
           "timeColumnType": "timestamp",
           "where": [
@@ -1033,943 +1417,10 @@
         "align": false,
         "alignLevel": null
       }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "description": "Time between block header arrival and the epoch time expected for the tipset of that block.",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 16,
-        "y": 18
-      },
-      "hiddenSeries": false,
-      "id": 18,
-      "interval": "1s",
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": false,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "format": "time_series",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  (recorded_at - header_timestamp) AS \"Delay\"\nFROM \"chain_block\"\nWHERE\n  $__timeFilter(\"time\") AND (recorded_at - header_timestamp) < 50000000000\nORDER BY 1",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "used_percent"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "table": "disk",
-          "timeColumn": "\"time\"",
-          "timeColumnType": "timestamp",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Block Header Delay",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ns",
-          "label": null,
-          "logBase": 10,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "datasource": null,
-      "description": "Lifetime Total blocks per Tipset",
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 16,
-        "y": 24
-      },
-      "id": 16,
-      "options": {
-        "colorMode": "value",
-        "fieldOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "defaults": {
-            "decimals": 2,
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [],
-          "values": false
-        },
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto"
-      },
-      "pluginVersion": "6.7.3",
-      "targets": [
-        {
-          "format": "time_series",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  NOW() AS \"time\",\n  count(cid)::float/max(height)::float AS \"block_tipset_ratio\"\nFROM \"blocks\"",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "pledged_collateral"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "table": "\"chain_economics\"",
-          "timeColumn": "\"time\"",
-          "timeColumnType": "timestamp",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Block-to-Tipset Ratio",
-      "type": "stat"
-    },
-    {
-      "datasource": null,
-      "description": "Total Tipsets on Chain",
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 24
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "fieldOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "defaults": {
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [],
-          "values": false
-        },
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto"
-      },
-      "pluginVersion": "6.7.3",
-      "targets": [
-        {
-          "format": "time_series",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  NOW() AS \"time\",\n  max(height) AS \"total_tipsets\"\nFROM \"blocks\"",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "pledged_collateral"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "table": "\"chain_economics\"",
-          "timeColumn": "\"time\"",
-          "timeColumnType": "timestamp",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Total Tipsets",
-      "type": "stat"
-    },
-    {
-      "aliasColors": {},
-      "bars": true,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "decimals": 0,
-      "description": "Total and failed Proof of SpaceTime being captured on-chain.",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 16,
-        "x": 0,
-        "y": 26
-      },
-      "hiddenSeries": false,
-      "id": 27,
-      "interval": "5s",
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": false,
-        "hideEmpty": false,
-        "hideZero": false,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": false,
-      "linewidth": 1,
-      "nullPointMode": "null as zero",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 3,
-      "points": true,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "failed",
-          "color": "#F2495C",
-          "zindex": 3
-        },
-        {
-          "alias": "total",
-          "color": "#73BF69",
-          "pointradius": 2
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "format": "time_series",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n\t$__unixEpochGroupAlias(b.timestamp,'5s'),\n-- \tm.cid,\n\tcount(1) filter (where r.exit != 0) AS failed,\n\tcount(1) AS total\nFROM messages m\nINNER JOIN receipts r ON m.cid = r.msg\nINNER JOIN block_messages bm ON m.cid = bm.message\nINNER JOIN blocks b ON bm.block = b.cid\nWHERE m.method = 5\nAND $__unixEpochFilter(b.timestamp)\nGROUP BY 1\nORDER BY 1",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "counter"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "table": "lotus_message_success",
-          "timeColumn": "\"time\"",
-          "timeColumnType": "timestamp",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "PoSt Submissions",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": 0,
-          "format": "short",
-          "label": "count",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "datasource": null,
-      "description": "Total Blocks on Chain",
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 28
-      },
-      "id": 5,
-      "options": {
-        "colorMode": "value",
-        "fieldOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "defaults": {
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [],
-          "values": false
-        },
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto"
-      },
-      "pluginVersion": "6.7.3",
-      "targets": [
-        {
-          "format": "time_series",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n  NOW() AS \"time\",\n  count(*) AS \"total_blocks\"\nFROM \"blocks\"",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "pledged_collateral"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "table": "\"chain_economics\"",
-          "timeColumn": "\"time\"",
-          "timeColumnType": "timestamp",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Total Blocks",
-      "type": "stat"
-    },
-    {
-      "content": "# Lotus Daemon",
-      "datasource": null,
-      "gridPos": {
-        "h": 2,
-        "w": 24,
-        "x": 0,
-        "y": 33
-      },
-      "id": 21,
-      "mode": "markdown",
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "description": "",
-      "fill": 3,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 35
-      },
-      "hiddenSeries": false,
-      "id": 22,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": false,
-        "hideEmpty": false,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null as zero",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 0.5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "Failure",
-          "color": "#E02F44"
-        },
-        {
-          "alias": "Success",
-          "color": "#96D98D"
-        }
-      ],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
-        {
-          "format": "time_series",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": false,
-          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  counter - lag(counter) OVER (ORDER BY \"time\") AS \"Success\"\nFROM lotus_message_success\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1",
-          "refId": "B",
-          "select": [
-            [
-              {
-                "params": [
-                  "counter"
-                ],
-                "type": "column"
-              },
-              {
-                "params": [
-                  "delta"
-                ],
-                "type": "window"
-              },
-              {
-                "params": [
-                  "Success"
-                ],
-                "type": "alias"
-              }
-            ]
-          ],
-          "table": "lotus_message_success",
-          "timeColumn": "\"time\"",
-          "timeColumnType": "timestamptz",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        },
-        {
-          "format": "time_series",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": false,
-          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  counter - lag(counter) OVER (ORDER BY \"time\") AS \"Failure\"\nFROM lotus_message_failure\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1",
-          "refId": "C",
-          "select": [
-            [
-              {
-                "params": [
-                  "counter"
-                ],
-                "type": "column"
-              },
-              {
-                "params": [
-                  "delta"
-                ],
-                "type": "window"
-              },
-              {
-                "params": [
-                  "Failure"
-                ],
-                "type": "alias"
-              }
-            ]
-          ],
-          "table": "lotus_message_failure",
-          "timeColumn": "\"time\"",
-          "timeColumnType": "timestamptz",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Messages Recieved",
-      "tooltip": {
-        "shared": true,
-        "sort": 1,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": null,
-          "format": "short",
-          "label": "",
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "description": "Number of peers connected to the lotus node.",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 9,
-        "x": 8,
-        "y": 35
-      },
-      "hiddenSeries": false,
-      "id": 24,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "format": "time_series",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": false,
-          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  gauge\nFROM lotus_peer_count\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "gauge"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "table": "lotus_peer_count",
-          "timeColumn": "\"time\"",
-          "timeColumnType": "timestamptz",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Connected Peers Count",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "description": "Duration reported by lotus between receipt and validation of a block.",
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 7,
-        "x": 17,
-        "y": 35
-      },
-      "hiddenSeries": false,
-      "id": 20,
-      "legend": {
-        "alignAsTable": false,
-        "avg": true,
-        "current": false,
-        "hideEmpty": false,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": false,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": true,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "Average Duration",
-          "legend": false,
-          "lines": true,
-          "points": false
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "format": "time_series",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": false,
-          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  gauge AS \"Validation Duration\"\nFROM lotus_block_validation_ms\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "gauge"
-                ],
-                "type": "column"
-              },
-              {
-                "params": [
-                  "Validation Duration"
-                ],
-                "type": "alias"
-              }
-            ]
-          ],
-          "table": "lotus_block_validation_ms",
-          "timeColumn": "\"time\"",
-          "timeColumnType": "timestamptz",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        },
-        {
-          "format": "time_series",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": false,
-          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  avg(gauge) OVER (ORDER BY \"time\" ROWS 20 PRECEDING) AS \"Average Duration\"\nFROM lotus_block_validation_ms\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1",
-          "refId": "B",
-          "select": [
-            [
-              {
-                "params": [
-                  "gauge"
-                ],
-                "type": "column"
-              },
-              {
-                "params": [
-                  "avg",
-                  "20"
-                ],
-                "type": "moving_window"
-              },
-              {
-                "params": [
-                  "Average Duration"
-                ],
-                "type": "alias"
-              }
-            ]
-          ],
-          "table": "lotus_block_validation_ms",
-          "timeColumn": "\"time\"",
-          "timeColumnType": "timestamptz",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Block Validation Time",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": null,
-          "format": "ms",
-          "label": "",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
     }
   ],
-  "refresh": "30s",
-  "schemaVersion": 22,
+  "refresh": "15m",
+  "schemaVersion": 26,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1981,9 +1432,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
       "1m",
       "5m",
       "15m",
@@ -1993,11 +1441,8 @@
       "1d"
     ]
   },
-  "timezone": "",
-  "title": "Sentinel (v0.1) (PainNet Dev)",
-  "uid": "sentinel_v0_1",
-  "variables": {
-    "list": []
-  },
-  "version": 16
+  "timezone": "browser",
+  "title": "Sentinel (v0.2) (Space Race)",
+  "uid": "sentinel_v0_2",
+  "version": 12
 }

--- a/grafana/provisioning/dashboards/mpool.json
+++ b/grafana/provisioning/dashboards/mpool.json
@@ -1,0 +1,797 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 5,
+  "links": [],
+  "panels": [
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": 2
+      },
+      "color": {
+        "cardColor": "#56A64B",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateViridis",
+        "exponent": 0.7,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 10,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.1.5",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "select \nraw.time, raw.\"10\" as \"0\",\nraw.\"20\" - raw.\"10\" as \"10\",\nraw.\"30\" - raw.\"20\" as \"20\",\nraw.\"45\" - raw.\"30\" as \"30\",\nraw.\"60\" - raw.\"45\" as \"45\",\nraw.\"90\" - raw.\"60\" as \"60\",\nraw.\"120\" - raw.\"90\" as \"90\",\nraw.\"240\" - raw.\"120\" as \"120\",\nraw.\"600\" - raw.\"240\" as \"240\",\nraw.\"1800\" - raw.\"600\" as \"600\",\nraw.\"3600\" - raw.\"1800\" as \"1800\",\nraw.\"count\" - raw.\"3600\" as \"3600\"\nFROM (SELECT\n  \"time\" AS \"time\",\n  (CASE WHEN \"10\" >= lag(\"10\") OVER (ORDER BY \"time\") THEN \"10\" - lag(\"10\") OVER (ORDER BY \"time\") WHEN lag(\"10\") OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE \"10\" END) AS \"10\",\n  (CASE WHEN \"20\" >= lag(\"20\") OVER (ORDER BY \"time\") THEN \"20\" - lag(\"20\") OVER (ORDER BY \"time\") WHEN lag(\"20\") OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE \"20\" END) AS \"20\",\n  (CASE WHEN \"30\" >= lag(\"30\") OVER (ORDER BY \"time\") THEN \"30\" - lag(\"30\") OVER (ORDER BY \"time\") WHEN lag(\"30\") OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE \"30\" END) AS \"30\",\n  (CASE WHEN \"45\" >= lag(\"45\") OVER (ORDER BY \"time\") THEN \"45\" - lag(\"45\") OVER (ORDER BY \"time\") WHEN lag(\"45\") OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE \"45\" END) AS \"45\",\n  (CASE WHEN \"60\" >= lag(\"60\") OVER (ORDER BY \"time\") THEN \"60\" - lag(\"60\") OVER (ORDER BY \"time\") WHEN lag(\"60\") OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE \"60\" END) AS \"60\",\n  (CASE WHEN \"90\" >= lag(\"90\") OVER (ORDER BY \"time\") THEN \"90\" - lag(\"90\") OVER (ORDER BY \"time\") WHEN lag(\"90\") OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE \"90\" END) AS \"90\",\n  (CASE WHEN \"120\" >= lag(\"120\") OVER (ORDER BY \"time\") THEN \"120\" - lag(\"120\") OVER (ORDER BY \"time\") WHEN lag(\"120\") OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE \"120\" END) AS \"120\",\n  (CASE WHEN \"240\" >= lag(\"240\") OVER (ORDER BY \"time\") THEN \"240\" - lag(\"240\") OVER (ORDER BY \"time\") WHEN lag(\"240\") OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE \"240\" END) AS \"240\",\n  (CASE WHEN \"600\" >= lag(\"600\") OVER (ORDER BY \"time\") THEN \"600\" - lag(\"600\") OVER (ORDER BY \"time\") WHEN lag(\"600\") OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE \"600\" END) AS \"600\",\n  (CASE WHEN \"1800\" >= lag(\"1800\") OVER (ORDER BY \"time\") THEN \"1800\" - lag(\"1800\") OVER (ORDER BY \"time\") WHEN lag(\"1800\") OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE \"1800\" END) AS \"1800\",\n  (CASE WHEN \"3600\" >= lag(\"3600\") OVER (ORDER BY \"time\") THEN \"3600\" - lag(\"3600\") OVER (ORDER BY \"time\") WHEN lag(\"3600\") OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE \"3600\" END) AS \"3600\",\n  (CASE WHEN \"count\" >= lag(\"count\") OVER (ORDER BY \"time\") THEN \"count\" - lag(\"count\") OVER (ORDER BY \"time\") WHEN lag(\"count\") OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE \"count\" END) AS \"count\"\nFROM lotusmpool_msg_wait\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1\n) as raw",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "\"10\""
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "increase"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "10"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "\"30\""
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "increase"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "30"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "\"60\""
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "increase"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "60"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "\"120\""
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "increase"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "120"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "\"240\""
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "increase"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "240"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "\"600\""
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "increase"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "600"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "\"1800\""
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "increase"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "1800"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "\"3600\""
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "increase"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "3600"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "table": "lotusmpool_msg_wait",
+          "timeColumn": "\"time\"",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Wait Time Histogram",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": null,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  (CASE WHEN counter >= lag(counter) OVER (ORDER BY \"time\") THEN counter - lag(counter) OVER (ORDER BY \"time\") WHEN lag(counter) OVER (ORDER BY \"time\") IS NULL THEN NULL ELSE counter END)/extract(epoch from \"time\" - lag(\"time\") OVER (ORDER BY \"time\")) AS \"counter\"\nFROM lotusmpool_msg_inbound\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "counter"
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "rate"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "counter"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "table": "lotusmpool_msg_inbound",
+          "timeColumn": "\"time\"",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Inbound Messages Rate since Last Measure",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": false,
+          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  gauge\nFROM lotusmpool_mpool_size\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "gauge"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "lotusmpool_mpool_size",
+          "timeColumn": "\"time\"",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Mpool Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 2,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "quantile",
+          "rawQuery": false,
+          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  quantile AS metric,\n  gauge\nFROM lotusmpool_mpool_age\nWHERE\n  $__timeFilter(\"time\")\nORDER BY \"time\", \"metric\"",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "gauge"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "lotusmpool_mpool_age",
+          "timeColumn": "\"time\"",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Mpool Age",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "transformations": [],
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 10,
+          "max": null,
+          "min": "5",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "sum"
+            },
+            "properties": []
+          }
+        ]
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "sum",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": false,
+          "rawSql": "SELECT\n  \"time\" AS \"time\",\n  count - lag(count) OVER (ORDER BY \"time\") AS \"count\",\n  sum\nFROM lotusmpool_msg_wait\nWHERE\n  $__timeFilter(\"time\")\nORDER BY 1",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "column"
+              },
+              {
+                "params": [
+                  "delta"
+                ],
+                "type": "window"
+              },
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "alias"
+              }
+            ],
+            [
+              {
+                "params": [
+                  "sum"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "lotusmpool_msg_wait",
+          "timeColumn": "\"time\"",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Mpool Wait Counts",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Mpool Stats",
+  "uid": "0CA9VFvGz",
+  "version": 14
+}

--- a/grafana/provisioning/dashboards/top_miner_block_reward.json
+++ b/grafana/provisioning/dashboards/top_miner_block_reward.json
@@ -15,15 +15,18 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 6,
+  "id": 1,
   "links": [],
   "panels": [
     {
+      "columns": [],
       "datasource": null,
-      "description": "The Epoch Miner Ranks was last update at.",
+      "description": "The height of the chain when the current ranking was produced.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
+          "custom": {
+            "align": null
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -31,71 +34,16 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
-          },
-          "unit": "none"
+          }
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 3,
-        "w": 11,
-        "x": 7,
-        "y": 0
-      },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^current_height$/",
-          "values": false
-        }
-      },
-      "pluginVersion": "7.0.3",
-      "targets": [
-        {
-          "format": "time_series",
-          "group": [],
-          "metricColumn": "none",
-          "rawQuery": true,
-          "rawSql": "SELECT\n NOW() as time,\n *\nFROM\n  top_miners_by_base_reward_max_height\n\n",
-          "refId": "A",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "timeColumn": "time",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Updated At",
-      "type": "stat"
-    },
-    {
-      "columns": [],
-      "datasource": null,
-      "description": "The height of the chain when the current ranking was produced.",
       "fontSize": "100%",
       "gridPos": {
         "h": 3,
@@ -104,7 +52,11 @@
         "y": 0
       },
       "id": 4,
+      "options": {
+        "showHeader": true
+      },
       "pageSize": null,
+      "pluginVersion": "7.1.5",
       "showHeader": true,
       "sort": {
         "col": 0,
@@ -171,6 +123,81 @@
       "type": "table"
     },
     {
+      "datasource": null,
+      "description": "The Epoch Miner Ranks was last update at.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 2,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^current_height$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\n NOW() as time,\n *\nFROM\n  top_miners_by_base_reward_max_height\n\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Updated At",
+      "type": "stat"
+    },
+    {
       "columns": [],
       "datasource": null,
       "description": "All accumulated rewards for miners updated each day at midnight.",
@@ -185,7 +212,7 @@
         "h": 25,
         "w": 11,
         "x": 7,
-        "y": 3
+        "y": 0
       },
       "id": 2,
       "pageSize": 50,
@@ -250,7 +277,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 25,
+  "schemaVersion": 26,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -276,8 +303,5 @@
   "timezone": "",
   "title": "Top Miners by Block Reward",
   "uid": "P_Q13JnMz",
-  "variables": {
-    "list": []
-  },
   "version": 2
 }


### PR DESCRIPTION
Note that this export is likely incompatible with older versions of Grafana and require an in-place upgrade. There shouldn't be any concerns on Sentinel with regard to the upgrade aside from the new dependency on image rendering (which has already been added).