### PR TITLE
Fills in baseURL variable, potential search fix.

### DIFF
--- a/docs/config/_default/config.toml
+++ b/docs/config/_default/config.toml
@@ -1,4 +1,4 @@
-baseurl = ""
+baseurl = "https://lilium.sh"
 canonifyURLs = false
 disableAliases = true
 disableHugoGeneratorInject = true


### PR DESCRIPTION
I'm pretty sure this is why the search isn't working. If this doesn't work, however, we might need to change `baseurl` to simply `"/"`.  That seems to work in [Lotus docs](https://github.com/filecoin-project/lotus-docs/blob/main/config/_default/config.toml#L1).