### PR TITLE
update docs for lily v0.10.0

### DIFF
--- a/docs/content/en/software/lily/operation.md
+++ b/docs/content/en/software/lily/operation.md
@@ -15,7 +15,14 @@ toc: true
 
 ## API endpoint
 
-When the daemon is started, the repo path is where this communication coordination is handled. The repo path contains information about where the JSON RPC API is (`api` file located in repo path) located, along with an authentication token used (`token` file) for writeable interactions. For more details, see the [Lotus API documentation](https://lotus.filecoin.io/reference/basics/api-access/).
+The daemon coordinates access to its API using the files within repo path. The repo path contains information about where the JSON RPC API is (`api` file located in repo path) located, along with an authentication token used (`token` file) for writeable interactions.
+
+    .lily/           <-- repo path root
+    ├── api          <-- for information about the JSON RPC API location
+    ├── token        <-- for write interactions
+    └── config.toml
+
+For more details, see the [Lotus API documentation](https://lotus.filecoin.io/reference/basics/api-access/).
 
 The IP/port to which the daemon binds can be managed via the `--api` flag. By default, the daemon binds to `localhost` and will be unavailable externally unless bound to a publicly-accessible IP.
 
@@ -26,16 +33,22 @@ The IP/port to which the daemon binds can be managed via the `--api` flag. By de
 Once the Lily daemon process is [running and fully synced](setup.md), you may manage its Jobs through the CLI. (Note: behavior is undefined if Lily is not fully synced, so one may gate the Job creation to wait for the sync to complete with `lily sync wait && lily ...`.).
 
 Jobs may be executed on a lily node via the `job run` command. The `job run` command accepts the following flags:
-- `--window` duration after which job execution will be canceled while processing a tipset.
+- `--window` duration after which job execution will be canceled while processing a tipset. (A duration string is a possibly signed sequence of decimal numbers, each with an optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".)
 - `--tasks` specify the list of [tasks](#tasks) to run by this job. Some tasks [will be heavier than others](hardware.md). A tipset is only processed when all tasks in the job have finished. Only then will Lily move to the next epoch. The default value of this flag if omitted is all tasks lily is capable of performing.
 - `--storage` specifies which of the configured storage outputs the job will write to.
 - `--name` specifies the name of the job for easy identification later. The provided value
   will appear as `reporter` in the `visor_processing_reports` table.
-- `--restart-delay` duration to wait before restarting job after it ends execution.
+- `--restart-delay` duration to wait before restarting job after it ends execution. (A duration string is a possibly signed sequence of decimal numbers, each with an optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".)
 - `--restart-on-failure` specifies if a job should be restarted if it fails.
 - `--restart-on-completion` specifies if a job should be restarted once it completes.
 
 Currently, Lily is capable of executing the following types of jobs:
+
+- [Watch](#watch)
+- [Walk](#walk)
+- [Find](#find)
+- [Fill](#fill)
+- [Survey](#survey)
 
 ### Watch
 The Watch command subscribes to incoming tipsets from the filecoin blockchain and indexes them as they arrive.

--- a/docs/content/en/software/lily/operation.md
+++ b/docs/content/en/software/lily/operation.md
@@ -34,7 +34,7 @@ Once the Lily daemon process is [running and fully synced](setup.md), you may ma
 
 Jobs may be executed on a lily node via the `job run` command. The `job run` command accepts the following flags:
 - `--window` duration after which job execution will be canceled while processing a tipset. (A duration string is a possibly signed sequence of decimal numbers, each with an optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".)
-- `--tasks` specify the list of [tasks](#tasks) to run by this job. Some tasks [will be heavier than others](hardware.md). A tipset is only processed when all tasks in the job have finished. Only then will Lily move to the next epoch. The default value of this flag if omitted is all tasks lily is capable of performing.
+- `--tasks` specify the list of [tasks](#tasks) to run. Some tasks [will be heavier than others](hardware.md). A tipset is only processed when all the specified tasks have finished. Only then will Lily move on to the next epoch. The default value of this flag is all tasks lily is capable of performing.
 - `--storage` specifies which of the configured storage outputs the job will write to.
 - `--name` specifies the name of the job for easy identification later. The provided value
   will appear as `reporter` in the `visor_processing_reports` table.

--- a/docs/content/en/software/lily/operation.md
+++ b/docs/content/en/software/lily/operation.md
@@ -15,7 +15,7 @@ toc: true
 
 ## API endpoint
 
-When the daemon is started, the repo path is where this communication coordination is handled. The repo path contains information about where the JSON RPC API is (`api` file located in repo path) located, along with an authentication token used (`token` file) for writeable interactions. For more details, see the [Lotus API documentation](https://docs.filecoin.io/build/lotus/).
+When the daemon is started, the repo path is where this communication coordination is handled. The repo path contains information about where the JSON RPC API is (`api` file located in repo path) located, along with an authentication token used (`token` file) for writeable interactions. For more details, see the [Lotus API documentation](https://lotus.filecoin.io/reference/basics/api-access/).
 
 The IP/port to which the daemon binds can be managed via the `--api` flag. By default, the daemon binds to `localhost` and will be unavailable externally unless bound to a publicly-accessible IP.
 

--- a/docs/content/en/software/lily/operation.md
+++ b/docs/content/en/software/lily/operation.md
@@ -139,7 +139,8 @@ over the specified range (`--from`,`--to`). An epoch is considered to have gaps 
 #### Constraints
 
 - The Find job must be executed **BEFORE** a Fill job. These jobs must **NOT** be performed simultaneously.
-- Do not execute the Find job over epoch ranges imported from the lily data archive as there are no processing reports for imported data.   
+- Executing the Find job over epoch ranges which have no processing reports will create GAP results for all epoch/tasks combinations.
+- Do not execute the Find job over epoch ranges imported from the lily data archive as there are no processing reports for imported data.
 
 ### Fill
 The Fill job queries the `visor_gap_reports` table for gaps to fill and indexes the data reported to have gaps.
@@ -151,7 +152,7 @@ filled, its corresponding entry in the `visor_gap_reports` table will be updated
 #### Constraints
 
 - The Fill job must be executed **AFTER** a Find job. These jobs must **NOT** be performed simultaneously.
-- Walk jobs may only be executed over epoch ranges lily has state. Walking ranges lily does not have a state for will result in the error: `blockstore: block not found` being written to the `errors_detected` column of the `visor_processing_reports` table.
+- Walk jobs may only be executed over epoch ranges lily has state. Walking epoch ranges which lily does not have state for will result in the error: `blockstore: block not found` being written to the `errors_detected` column of the `visor_processing_reports` table.
 - Do not execute the Fill job over epoch ranges imported from the lily data archive as there are no processing reports for imported data.
 
 ### Survey

--- a/docs/content/en/software/lily/operation.md
+++ b/docs/content/en/software/lily/operation.md
@@ -15,186 +15,39 @@ toc: true
 
 ## API endpoint
 
-When the daemon is started, the repo path is where this communication
-coordination is handled. The repo path contains information about where the
-JSON RPC API is (`api` file located in repo path) located along with an
-authentication token used (`token` file) for writeable interactions. For more
-details see the
-[Lotus API documentation](https://docs.filecoin.io/build/lotus/).
+When the daemon is started, the repo path is where this communication coordination is handled. The repo path contains information about where the JSON RPC API is (`api` file located in repo path) located, along with an authentication token used (`token` file) for writeable interactions. For more details, see the [Lotus API documentation](https://docs.filecoin.io/build/lotus/).
 
-The IP/port which the daemon binds to can be managed via the `config.toml` or
-by passing the value to `--api`. By default, the daemon binds to `localhost`
-and will be unavailable externally unless bound to a publicly-accessible IP.
+The IP/port to which the daemon binds can be managed via the `--api` flag. By default, the daemon binds to `localhost` and will be unavailable externally unless bound to a publicly-accessible IP.
 
 ---
 
 ## Jobs
 
-Once the Lily daemon process is [running and fully synced](setup.md), you may
-manage its Jobs through the CLI. (Note: behaviour is undefined if Lily is not
-fully synced, so one may gate the Job creation to wait for sync to complete
-with `lily sync wait && lily ...`.).
+Once the Lily daemon process is [running and fully synced](setup.md), you may manage its Jobs through the CLI. (Note: behavior is undefined if Lily is not fully synced, so one may gate the Job creation to wait for the sync to complete with `lily sync wait && lily ...`.).
 
 Jobs may be executed on a lily node via the `job run` command. The `job run` command accepts the following flags:
 - `--window` duration after which job execution will be canceled while processing a tipset.
-- `--tasks` specifies the list of [tasks](#tasks) to run by this job. Some
-  tasks [will be heavier than others](hardware.md). A tipset is only
-  processed when all tasks in the job have finished. Only then will Lily
-  move to the next epoch.
+- `--tasks` specify the list of [tasks](#tasks) to run by this job. Some tasks [will be heavier than others](hardware.md). A tipset is only processed when all tasks in the job have finished. Only then will Lily move to the next epoch. The default value of this flag if omitted is all tasks lily is capable of performing.
 - `--storage` specifies which of the configured storage outputs the job will write to.
 - `--name` specifies the name of the job for easy identification later. The provided value
   will appear as `reporter` in the `visor_processing_reports` table.
 - `--restart-delay` duration to wait before restarting job after it ends execution.
-- `--restart-on-failure` specifies if a job should be restarted in the event it fails.
+- `--restart-on-failure` specifies if a job should be restarted if it fails.
 - `--restart-on-completion` specifies if a job should be restarted once it completes.
 
 Currently, Lily is capable of executing the following types of jobs:
 
 ### Watch
-The Watch command subscribes to incoming tipsets from the filecoin blockchain and indexes them as the arrive.
+The Watch command subscribes to incoming tipsets from the filecoin blockchain and indexes them as they arrive.
 
-Since it may be the case that tipsets arrive at a rate greater than their rate of indexing the watch job maintains a
+Since it may be the case that tipsets arrive at a rate greater than lily's rate of indexing, the watch job maintains a
 buffer of tipsets to index. Consumption of this queue can be configured via the `--workers` flag. Increasing the value
 provided to the `--workers` flag will allow the watch job to index tipsets simultaneously.
 (Note: this will use a significant amount of system resources).
 
-Since it may be the case that lily experiences a reorg while the watch job is observing the head of the chain
-the `--confidence` flag may be used to buffer the amount of tipsets observed before it begins indexing.
+While watching a network with distributed consensus, participants may occasionally have intermittent connectivity problems, which cause some nodes to have different views of the blockchain HEAD. Eventually, the connectivity issues resolve, the nodes connect, and they reconcile their differences. The node which is found to be on the wrong branch will reorganize its local state to match the new network consensus by "unwinding" the incorrect chain of tipsets up to the point of disagreement (the "fork") and then applying the correct chain of tipsets. This can be referred to as a "reorg." The number of tipsets that are "unwound" from the incorrect chain is called "reorg depth."
 
-### Walk
-The Walk command will index state based on the list of tasks (`--tasks`) provided over the specified range
-(`--from`, `--to`). Each epoch will be indexed serially starting from the heaviest tipset at the upper height
-(`--to`) to the lower height (`--from`).
-
-### Find
-The Find job searches for gaps in a database storage system by executing the SQL `gap_find()` function over the
-`visor_processing_reports` table. Find will query the database for gaps based on the list of tasks (`--tasks`) provided
-over the specified range (`--from`,`--to`). An epoch is considered to have gaps if and only if:
-1. task specified by the `--task` flag is not present at each epoch within the specified range.
-2. a task specified by the `--task` flag does not have status `'OK'` at each epoch within the specified range.
-  The results of the find job are written to the `visor_gap_reports` table with status `'GAP'`.
-
-**Constraint**: the Find job must be executed **BEFORE** a Fill job. These jobs must **NOT** be executed simultaneously.
-    
-### Fill
-The Fill job queries the `visor_gap_reports` table for gaps to fill and indexes the data reported to have gaps.
-A gap in the `visor_gap_reports` table is any row with status `'GAP'`. Fill will index gaps based on the list
-of tasks (`--tasks`) provided over the specified range (`--from`, `--to`). Each epoch and its corresponding list of
-tasks found in the `visor_gap_reports` table will be indexed independently. When the gap is successfully
-filled its corresponding entry in the `visor_gap_reports` table will be updated with status `'FILLED'`.
-
-**Constraint**: the Fill job must be executed **AFTER** a Find job. These jobs must **NOT** be executed simultaneously.
-
->>>>>>> b749921 (firest pass wip)
-
-When Jobs are launched on a running daemon, a new Job (with ID) is
-created. These jobs may be managed using the `lily job` CLI:
-
-```
-# shows all Jobs and their status
-$ lily job list
-# stop a running Job
-$ lily job stop
-# allows a stopped Job to be resumed (new Jobs are not created this way)
-$ lily job start
-```
-
-Example job list output:
-
-```
-$ lily job list
-[
-        ...
-        {
-                "ID": 1,
-                "Name": "customtaskname",
-                "Type": "watch",
-                "Error": "",
-                "Tasks": [
-                        "blocks",
-                        "messages",
-                        "chaineconomics",
-                        "actorstatesraw",
-                        "actorstatespower",
-                        "actorstatesreward",
-                        "actorstatesmultisig",
-                        "msapprovals"
-                ],
-                "Running": true,
-                "RestartOnFailure": true,
-                "RestartOnCompletion": false,
-                "RestartDelay": 0,
-                "Params": {
-                        "confidence": "100",
-                        "storage": "db",
-                        "window": "30s"
-                },
-                "StartedAt": "2021-08-27T21:56:49.045783716Z",
-                "EndedAt": "0001-01-01T00:00:00Z"
-        }
-        ...
-]
-```
-
-
----
-
-## Tasks
-
-Lily provides several tasks to capture different aspects of the blockchain
-state. The type of data extracted extracted by Lily is controlled by the below
-tasks. Jobs accepts tasks to run as a comma separated list. The data extracted
-by a task is stored in its related Models.
-
-|        Task         |                                                                                                                                                                                                      Description                                                                                                                                                                                                      |                                                                                                                                                                                                                                                                                                                                           Models                                                                                                                                                                                                                                                                                                                                            | Duration Per Tipset (Estimate) |
-| :-----------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------: |
-|       blocks        |                                                                                                                                                                                  Captures data about blocks and their relationships                                                                                                                                                                                   |                                                                                                                                                                                                                                            [block_headers]({{< ref "/data/models.md#block_headers" >}}), [block_parents]({{< ref "/data/models.md#block_parents" >}}), [drand_block_entries]({{< ref "/data/models.md#drand_block_entries" >}})                                                                                                                                                                                                                                             |              1 ms              |
-|   chaineconomics    |                                                                                                                                                                                       Captures circulating supply information.                                                                                                                                                                                        |                                                                                                                                                                                                                                                                                                            [chain_economics]({{< ref "/data/models.md#drand_block_entries" >}})                                                                                                                                                                                                                                                                                                             |             50 ms              |
-|      consensus      |                                                                                                                                                                           Captures consensus view of the chain which includes null rounds.                                                                                                                                                                            |                                                                                                                                                                                                                                                                                                              [chain_consensus]({{< ref "/data/models.md#chain_consensus" >}})                                                                                                                                                                                                                                                                                                               |              1 ms              |
-|      messages       | Captures data about messages that were carried in a tipset's blocks. The receipt is also captured for any messages that were executed. Detailed information about gas usage by each messages as well as a summary of gas usage by all messages is also captured. The task does not produce any data until it has seen two tipsets since receipts are carried in the tipset following the one containing the messages. |                                                                                                                                               [block_messages]({{< ref "/data/models.md#block_messages" >}}), [derived_gas_outputs]({{< ref "/data/models.md#derived_gas_outputs" >}}), [messages]({{< ref "/data/models.md#messages" >}}), [messages_gas_economy]({{< ref "/data/models.md#messages_gas_economy" >}}), [parsed_messages]({{< ref "/data/models.md#parsed_messages" >}}), [receipts]({{< ref "/data/models.md#receipts" >}}),                                                                                                                                               |             50 ms              |
-|   implicitmessage   |                                                                                                                                          Captures internal message sends not appearing on chain including Multisig actor sends, Cron Event Ticks, Block and Reward Messages                                                                                                                                           |                                                                                                                                                                                                                                                                  [internal_messages]({{< ref "/data/models.md#internal_messages" >}}), [internal_parsed_messages]({{< ref "/data/models.md#internal_parsed_messages" >}})                                                                                                                                                                                                                                                                   |              1 ms              |
-|     msapprovals     |                                                                                                                                                                                     Captures approvals of multisig gated messages                                                                                                                                                                                     |                                                                                                                                                                                                                                                                                                           [multisig_approvals]({{< ref "/data/models.md#multisig_approvals" >}})                                                                                                                                                                                                                                                                                                            |             10 ms              |
-|   actorstatesraw    |                                                                                                                                            Captures basic actor properties for any actors that have changed state and serializes a shallow form of the new state to JSON.                                                                                                                                             |                                                                                                                                                                                                                                                                                         [actors]({{< ref "/data/models.md#actors" >}}), [actor_states]({{< ref "/data/models.md#actor_states" >}})                                                                                                                                                                                                                                                                                          |             50 ms              |
-| actorstatesverifreg |                                                                                                                                                                    Captures changes to the verified registry actor and verified registry clients.                                                                                                                                                                     |                                                                                                                                                                                                                                              [verified_registry_verified_clients]({{< ref "/data/models.md#verified_registry_verified_clients" >}}), [verified_registry_verifiers]({{< ref "/data/models.md#verified_registry_verifiers" >}})                                                                                                                                                                                                                                               |             10 ms              |
-| actorstatesmultisig |                                                                                                                                                                                Captures changes to multisig actors transaction state.                                                                                                                                                                                 |                                                                                                                                                                                                                                                                                                        [multisig_transactions]({{< ref "/data/models.md#multisig_transactions" >}})                                                                                                                                                                                                                                                                                                         |             100 ms             |
-|  actorstatesreward  |                                                                                                                                                         Captures changes to the reward actors state including information about miner rewards for each epoch.                                                                                                                                                         |                                                                                                                                                                                                                                                                                                                 [chain_reward]({{< ref "/data/models.md#chain_reward" >}})                                                                                                                                                                                                                                                                                                                  |             100 ms             |
-|   actorstatesinit   |                                                                                                                                               Captures changes to the init actor to provide mappings between canonical ID-addresses and actor addresses or public keys.                                                                                                                                               |                                                                                                                                                                                                                                                                                                                   [id_address]({{< ref "/data/models.md#id1_address" >}})                                                                                                                                                                                                                                                                                                                   |              3 s               |
-|  actorstatespower   |                                                                                                                                                 Captures changes to the power actors state including total power at each epoch and updates to the miner power claims.                                                                                                                                                 |                                                                                                                                                                                                                                                                             [chain_powers]({{< ref "/data/models.md#chain_powers" >}}), [power_actor_claims]({{< ref "/data/models.md#power_actor_claims" >}})                                                                                                                                                                                                                                                                              |              5 s               |
-|  actorstatesmarket  |                                                                                                                                                             Captures new deal proposals and changes to deal states recorded by the storage market actor.                                                                                                                                                              |                                                                                                                                                                                                                                                                    [market_deal_proposals]({{< ref "/data/models.md#market_deal_proposals" >}}), [market_deal_states]({{< ref "/data/models.md#market_deal_states" >}})                                                                                                                                                                                                                                                                     |              10 s              |
-|  actorstatesminer   |                                                                                                                                                            Captures changes to miner actors to provide information about sectors, posts, and locked funds.                                                                                                                                                            | [miner_current_deadline_infos]({{< ref "/data/models.md#miner_current_deadline_infos" >}}), [miner_fee_debts]({{< ref "/data/models.md#miner_fee_debts" >}}), [miner_locked_funds]({{< ref "/data/models.md#miner_locked_funds" >}}), [miner_infos]({{< ref "/data/models.md#miner_infos" >}}), [miner_sector_posts]({{< ref "/data/models.md#miner_sector_posts" >}}), [miner_pre_commit_infos]({{< ref "/data/models.md#miner_pre_commit_infos" >}}), [miner_sector_infos]({{< ref "/data/models.md#miner_sector_infos" >}}),            [miner_sector_events]({{< ref "/data/models.md#miner_sector_events" >}}), [miner_sector_deals]({{< ref "/data/models.md#miner_sector_deals" >}}) |              18 s              |
-
-`lily help tasks` provides additional information about the different types of
-tasks.
-
-Example, for starting a watch job named "lily-watch-job" pointed at the
-"analysis" storage target with a subset of tasks:
-
-```
-$ lily job run watch --name="lily-watch-job" --storage=analysis --tasks="messages, blocks, msapprovals"
-```
-
-
----
-
-## Job Confidence
-  * [ ]
-A network with distributed consensus may occasionally have intermittent
-connectivity problems which cause some nodes to have different views of the
-true blockchain HEAD. Eventually, the connectivity issues resolve, the nodes
-connect, and they reconcile their differences. The node which is found to be
-on the wrong branch will reorganize its local state to match the new network
-consensus by "unwinding" the incorrect chain of tipsets up to the point of
-disagreement (the "fork") and then applying the correct chain of tipsets. This
-can be referred to as a "reorg". The number of tipsets which are "unwound"
-from the incorrect chain is referred to as "reorg depth".
-
-Lily makes use of a "confidence" FIFO cache which gives the operator
-confidence that the tipsets which are being processed and persisted are
-unlikely to be reorganized. A confidence of 100 would establish a cache which
-will fill with as many tipsets. Once the 101st tipset is unshifted onto the
-cache stack, the 1st tipset would be popped off the bottom and have the Tasks
-processed over it. In the event of a reorg, the most recent tipsets are
-shifted off the top and the correct tipsets are unshifted in their place.
+Lily uses a "confidence" FIFO cache, which gives the operator confidence that the tipsets that are being processed and persisted are unlikely to be reorganized. A confidence of 100 would establish a cache that will fill with as many tipsets. Once the 101st tipset is unshifted onto the cache stack, the 1st tipset would be popped off the bottom and have the Tasks processed over it. In the event of a reorg, the most recent tipsets are shifted off the top, and the correct tipsets are unshifted in their place.
 
 Example:
 
@@ -202,8 +55,7 @@ Example:
 $ lily job run watch --confidence=10
 ```
 
-A visualization of the confidence cache during normal operation. Data is only
-extracted from tipsets marked with `(process)`:
+A visualization of the confidence cache during normal operation. Data is only extracted from tipsets marked with `(process)`:
 
 ```
              *unshift*        *unshift*      *unshift*       *unshift*
@@ -235,7 +87,6 @@ extracted from tipsets marked with `(process)`:
 A visualization of the confidence cache during a reorg of depth=2:
 
 ```
-
   *unshift*    *shift*    *shift*  *unshift*  *unshift*  *unshift*
      │  │       ▲  ▲       ▲  ▲       │  │       │  │       │  │
    ┌─▼──▼─┐   ┌─│──│─┐   ┌─│──│─┐   ┌─│──│─┐   ┌─▼──▼─┐   ┌─▼──▼─┐
@@ -261,38 +112,224 @@ A visualization of the confidence cache during a reorg of depth=2:
 
 ```
 
-Low confidence values may risk that Lily extracts data from tipsets that are
-not part of the final chain, which is something that you may want or not,
-depending on what you are trying to index.
+Low confidence values may risk that Lily extracts data from tipsets that are not part of the final chain, which is something that you may want or not, depending on what you are trying to index.
 
-## Timeout window
+#### Constraints
 
-The `lily job run --window [walk|watch] ` flag controls how long Lily let tasks
-run. Since the network produces a tipset every 30 seconds, Lily will fall
-behind if processing all tasks in a job takes longer than that. Thus, by
-default any task(s) not completed within the window will be marked as
-incomplete (shown as `SKIP` in the processing_reports table when using a
-PostgreSQL storage target).
+- Lily's sync of the filecoin blockchain must be completed before starting a watch job. Users of lily may run the `lily sync wait` command to check if their node has completed syncing the chain. The command will exit when sync is complete.
 
-The `30s` default can be increased to accomodate deviations (i.e. sometimes
-the actorstateminer task might take 40s and some other times 15s, so Lily does
-not fall behind).
+### Walk
+The Walk command will index the state based on the list of tasks (`--tasks`) provided over the specified range
+(`--from`, `--to`). Each epoch will be indexed serially, starting from the heaviest tipset at the upper height
+(`--to`) to the lower height (`--from`).
+
+#### Constraints
+
+- Walk jobs may only be executed over epoch ranges lily has state. Walking ranges lily does not have a state for will result in the error: `blockstore: block not found` being written to the `errors_detected` column of the `visor_processing_reports` table.
+
+### Find
+The Find job searches for gaps in a database storage system by executing the SQL `gap_find()` function over the
+`visor_processing_reports` table. Find will query the database for gaps based on the list of tasks (`--tasks`) provided
+over the specified range (`--from`,`--to`). An epoch is considered to have gaps if and only if:
+
+1. Tasks specified by the `--tasks` flag are not present at each epoch within the specified range.
+2. Task specified by the `--tasks` flag do not have the status `'OK'` at each epoch within the specified range.
+    The find job results are written to the `visor_gap_reports` table with the status `'GAP'`.
+
+#### Constraints
+
+- The Find job must be executed **BEFORE** a Fill job. These jobs must **NOT** be performed simultaneously.
+- Do not execute the Find job over epoch ranges imported from the lily data archive as there are no processing reports for imported data.   
+
+### Fill
+The Fill job queries the `visor_gap_reports` table for gaps to fill and indexes the data reported to have gaps.
+A gap in the `visor_gap_reports` table is any row with the status `'GAP'`. Fill will index gaps based on the list
+of tasks (`--tasks`) provided over the specified range (`--from`, `--to`). Each epoch and its corresponding list of
+tasks found in the `visor_gap_reports` table will be indexed independently. When the gap is successfully
+filled, its corresponding entry in the `visor_gap_reports` table will be updated with' FILLED' status.
+
+#### Constraints
+
+- The Fill job must be executed **AFTER** a Find job. These jobs must **NOT** be performed simultaneously.
+- Walk jobs may only be executed over epoch ranges lily has state. Walking ranges lily does not have a state for will result in the error: `blockstore: block not found` being written to the `errors_detected` column of the `visor_processing_reports` table.
+- Do not execute the Fill job over epoch ranges imported from the lily data archive as there are no processing reports for imported data.
+
+### Survey
+
+The Survey job collects information on the filecoin peer agents lily is connected to. The frequency at which lily collects this information may be configured via the `--interval` flag. Currently, this job only has one task type: `peeragents`. Note that this task name is distinct from the task names `watch`, `walk`, `find`, and `fill` jobs accept.
+
+## Distributed TipSet Workers
+
+Lily may be configured to use Redis as a distributed task queue to distribute work across multiple lily instances. When configured this way the system of lily nodes can consist of multiple `Workers` and a single `Notifier` :
+
+- The `Notifier` puts tasks into a queue for execution by a `Worker`.
+- The `Workers` remove tasks from the queue for execution.
+
+The configuration described here should be used when multiple machines are available for running lily nodes as it allows the work of processing tasks to be distributed across a pool of machines. Internally, lily uses [asynq](https://github.com/hibiken/asynq) for distributed task queue orchestration.
+
+### Notifier
+
+A lily node may be configured to operate as a notifier using the `notify` subcommand on the `watch`, `walk`, and `fill` commands. For example:
+```bash
+$ lily job run --tasks=block_header watch notify --queue="Notifier1"
+```
+
+will cause the watch job to insert tasks into the queue based on the configuration with the name `Notifier1`. In this mode of operation, lily will distribute watch tasks to a Redis queue for consumption by `Workers` instead of performing the indexing locally. The values specified by the `--task` flag will be passed along to the `Workers`, however, the `--storage` flag will be ignored since lily isn't processing the watch tasks locally. 
+
+Similar to the above watch command, the walk command below:
+
+```bash
+$ lily job run walk --from=100 --to=200 notify --queue="Notifier1"
+```
+
+will cause the walk job to insert tasks into the queue configuration with the name `Notifier1` as they are walked by the notifier.
+
+### Worker
+
+A lily node may be configured to operate as a worker using the `tipset-worker` command. A `tipset-worker` consumes tasks (produced by a `notifier`) from a Redis queue and processes them. For example, the below command starts a `tipset-worker` that consumes tasks based on the configuration with the name `Worker1`:
+```bash
+$ lily job run --storage="Database1" tipset-worker --queue="Worker1"
+```
+
+In this mode of operation, lily will pull tasks from a Redis instance for processing, writing the results to the storage backend at configuration `Database1`. Below is an example of a `Worker` configuration:
+
+```toml
+[Queue.Workers.Worker1]
+  [Queue.Workers.Worker1.RedisConfig]
+    Network = "tcp"
+    Addr = "localhost:6379"
+    Username = "default"
+    PasswordEnv = "LILY_REDIS_PASSWORD"
+    DB = 0
+    PoolSize = 0
+[Queue.Workers.Worker1.WorkerConfig]
+    # Defines how many tasks a worker may process in parallel
+    Concurrency = 1
+    # Logging level of internal task system
+    LoggerLevel = "debug"
+    # Priorities of corresponding queues:
+    #   processes Watch tasks 50% of the time.
+    #   processes Fill tasks 30% of the time.
+    #   processes Index tasks 10% of the time.
+    #   processes Walk tasks 10% of the time
+    WatchQueuePriority = 5
+    FillQueuePriority = 3
+    IndexQueuePriority = 1
+    WalkQueuePriority = 1
+    # If true, the queues with higher priority are always processed first.
+    # Else queues with lower priority are processed only if all the other queues with higher priorities are empty.
+    StrictPriority = false
+    # Specifies the duration to wait to let workers finish their tasks
+    ShutdownTimeout = 30000000000
+```
+
+## Tasks
+
+Lily provides several tasks to capture different aspects of the blockchain state. The type of data extracted by Lily is controlled by the below tasks. Jobs accepts tasks to run as a comma-separated list. The data extracted by a task is stored in its related Models.
+
+| Name                              |                            Model                             | Duration |
+| --------------------------------- | :----------------------------------------------------------: | -------- |
+| actor                             |        [actors]({{< ref "/data/models.md#actors" >}})        | 10s      |
+| actor_state                       |  [actor_states]({{< ref "/data/models.md#actor_states" >}})  | 10s      |
+| block_header                      | [block_headers]({{< ref "/data/models.md#block_headers" >}}) | 1s       |
+| block_message                     | [block_messages]({{< ref "/data/models.md#block_messages" >}}) | 15s      |
+| block_parent                      | [block_parents]({{< ref "/data/models.md#block_parents" >}}) | 1s       |
+| chain_consensus                   | [chain_consensus]({{< ref "/data/models.md#chain_consensus" >}}) | 1s       |
+| chain_economics                   | [chain_economics]({{< ref "/data/models.md#chain_economics" >}}) | 1s       |
+| chain_power                       |  [chain_powers]({{< ref "/data/models.md#chain_powers" >}})  | 10s      |
+| chain_reward                      | [chain_rewards]({{< ref "/data/models.md#chain_rewards" >}}) | 10s      |
+| derived_gas_outputs               | [derived_gas_outputs]({{< ref "/data/models.md#derived_gas_outputs" >}}) | 15s      |
+| drand_block_entrie                | [drand_block_entries]({{< ref "/data/models.md#drand_block_entries" >}}) | 1s       |
+| id_address                        |  [id_addresses]({{< ref "/data/models.md#id_addresses" >}})  | 30s      |
+| internal_messages                 | [internal_messages]({{< ref "/data/models.md#internal_messages" >}}) | 10s      |
+| internal_parsed_messages          | [internal_parsed_messages]({{< ref "/data/models.md#internal_parsed_messages" >}}) | 10s      |
+| market_deal_proposal              | [market_deal_proposals]({{< ref "/data/models.md#market_deal_proposals" >}}) | 30s      |
+| market_deal_state                 | [market_deal_states]({{< ref "/data/models.md#market_deal_states" >}}) | 30s      |
+| message                           |      [messages]({{< ref "/data/models.md#messages" >}})      | 15s      |
+| message_gas_economy               | [message_gas_economy]({{< ref "/data/models.md#message_gas_economy" >}}) | 15s      |
+| miner_current_deadline_info       | [miner_current_deadline_infos]({{< ref "/data/models.md#miner_current_deadline_infos" >}}) | 10s      |
+| miner_fee_debt                    | [miner_fee_debts]({{< ref "/data/models.md#miner_fee_debts" >}}) | 15s      |
+| miner_info                        |   [miner_infos]({{< ref "/data/models.md#miner_infos" >}})   | 30s      |
+| miner_locked_fund                 | [miner_locked_funds]({{< ref "/data/models.md#miner_locked_funds" >}}) | 30s      |
+| miner_pre_commit_info             | [miner_pre_commit_infos]({{< ref "/data/models.md#miner_pre_commit_infos" >}}) | 60s      |
+| miner_sector_deal                 | [miner_sector_deals]({{< ref "/data/models.md#miner_sector_deals" >}}) | 60s      |
+| miner_sector_event                | [miner_sector_events]({{< ref "/data/models.md#miner_sector_events" >}}) | 60s      |
+| miner_sector_infos                | [miner_sector_infos]({{< ref "/data/models.md#miner_sector_infos" >}}) | 60s      |
+| miner_sector_infos_v7             | [miner_sector_infos_v7]({{< ref "/data/models.md#miner_sector_infos_v7" >}}) | 60s      |
+| miner_sector_post                 | [miner_sector_posts]({{< ref "/data/models.md#miner_sector_posts" >}}) | 15s      |
+| multisig_approvals                | [multisig_approvals]({{< ref "/data/models.md#multisig_approvals" >}}) | 15s      |
+| multisig_transaction              | [multisig_transactions]({{< ref "/data/models.md#multisig_transactions" >}}) | 15s      |
+| parsed_message                    | [parsed_messages]({{< ref "/data/models.md#parsed_messages" >}}) | 15s      |
+| power_actor_claim                 | [power_actor_claims]({{< ref "/data/models.md#power_actor_claims" >}}) | 15s      |
+| receipt                           |      [receipts]({{< ref "/data/models.md#receipts" >}})      | 15s      |
+| verified_registry_verified_client | [verified_registry_verified_clients]({{< ref "/data/models.md#verified_registry_verified_clients" >}}) | 10s      |
+| verified_registry_verifier        | [verified_registry_verifiers]({{< ref "/data/models.md#verified_registry_verifiers" >}}) | 10s      |
+
+## Job Managment
+
+When Jobs are launched on a running daemon, a new Job (with ID) is created. These jobs may be managed using the `lily job` CLI:
+
+```
+# launch a job
+$ lily job run [watch|walk|find|fill|survey|tipset-worker]
+
+# shows all Jobs and their status
+$ lily job list
+
+# stop a running Job
+$ lily job stop
+
+# allows a stopped Job to be resumed (new Jobs are not created this way)
+$ lily job start
+```
+
+Example job list output:
+
+```
+$ lily job list
+[
+	{
+		"ID": 1,
+		"Name": "custom-job-name",
+		"Type": "watch",
+		"Error": "",
+		"Tasks": [
+			"id_address",
+			"receipt",
+			"message_gas_economy",
+			"message",
+			"drand_block_entrie",
+			"derived_gas_outputs",
+			"chain_economics",
+			"chain_consensus",
+			"block_parent",
+			"block_message",
+			"block_header"
+		],
+		"Running": true,
+		"RestartOnFailure": false,
+		"RestartOnCompletion": false,
+		"RestartDelay": 0,
+		"Params": {
+			"buffer": "5",
+			"confidence": "5",
+		},
+		"StartedAt": "2022-05-27T20:58:43.054786488Z",
+		"EndedAt": "0001-01-01T00:00:00Z"
+	}
+]
+```
 
 ---
 
 
-## Job performance
+## Job Performance
 
-Lily captures details about each Task completed within the configured storage
-in a table called `visor_processing_reports`. This table includes the height,
-state_root, reporter (via configured [ApplicationName](setup.md)), task,
-started/completed timestamps, status, and errors (if any). This provides
-task-level insight on how Lily is progressing with the provided Jobs as well
-as any internal errors.
+Lily captures details about each Task completed within the configured storage in a table called `visor_processing_reports`. This table includes the height, state_root, reporter (via `--name` flag), task, started/completed timestamps, status, and errors (if any). This provides task-level insight into how Lily is progressing with the provided Jobs and any internal errors.
 
 ---
 
-## Metrics, traces and debugging
+## Metrics & Debugging
 
 
 #### Prometheus Metrics
@@ -307,8 +344,7 @@ may be bound to a custom IP/port by passing `--prometheus-port="0.0.0.0:9991"`
 on daemon startup with your custom values. `lily help monitoring` provides
 more information.
 
-A description of the metrics are included inline in the reply. A sample may be
-captured using curl:
+A description of the metrics is included inline in the reply. A sample may be captured using curl:
 
 ```
 $ curl 0.0.0.0:9991/metrics -o lily_prom_sample.txt

--- a/docs/content/en/software/lily/setup.md
+++ b/docs/content/en/software/lily/setup.md
@@ -114,14 +114,56 @@ which should be downloaded in advance (same as in Lotus).
 
 ## Configure
 
+The configuration file is the same configuration file as Lotus, but it also contains additional `Storage` and `Queue` sections that are specific to Lily.
+
+### Notifier & Worker Queue Definitions
+
+Lily may be configured to use Redis as a distributed task queue to distribute work across multiple lily instances. When configured this way the system of lily nodes can consist of multiple `Workers` and a single `Notifier` :
+
+* The `Notifier` puts tasks into a queue for execution by a `Worker`.
+* The `Workers` remove tasks from the queue and execute them.
+* Tasks are processed concurrently by multiple workers.
+
+The `Notifier` and `Workers` should be enumerated with a unique `[Name]` which will be used as an argument (via `--queue`) when starting a `[watch|walk|fill] notify` or `tipset-worker` job.
+
+An example of the `Queue` section:
+
+```toml
+[Queue]
+  [Queue.Notifiers]
+    [Queue.Notifiers.Notifier1]
+      Network = "tcp"
+      Addr = "localhost:6379"
+      Username = "default"
+      PasswordEnv = "LILY_REDIS_PASSWORD"
+      DB = 0
+      PoolSize = 0
+  [Queue.Workers]
+    [Queue.Workers.Worker1]
+      [Queue.Workers.Worker1.RedisConfig]
+        Network = "tcp"
+        Addr = "localhost:6379"
+        Username = "default"
+        PasswordEnv = "LILY_REDIS_PASSWORD"
+        DB = 0
+        PoolSize = 0
+      [Queue.Workers.Worker1.WorkerConfig]
+        Concurrency = 1
+        LoggerLevel = "debug"
+        WatchQueuePriority = 5
+        FillQueuePriority = 3
+        IndexQueuePriority = 1
+        WalkQueuePriority = 1
+        StrictPriority = false
+        ShutdownTimeout = 30000000000
+
+```
+
+This should be modified to meet your needs.
+
 ### Storage definitions
 
-The configuration file the [same configuration file as Lotus], but it contains
-an additional `Storage` section that is specific to Lily.
-
-Lily can deliver scraped data to multiple PostgreSQL and File destinations on
-a per-Task basis. Each destination should be enumerated with a unique `[Name]`
-which will be used as an argument (via `--storage`) when starting a Task.
+Lily can deliver scraped data to multiple PostgreSQL and File destinations on a per-Task basis. Each destination should be enumerated with a unique `[Name]` which will be used as an argument (via `--storage`) when starting a Task.
 
 An example of the `Storage` section:
 


### PR DESCRIPTION
Updates docs with details for running lily as a distributed set of nodes (workers and notifiers).
Also updates descriptions for types of jobs.