### PR TITLE
Add new GCS links

### DIFF
--- a/docs/content/en/data/dumps.md
+++ b/docs/content/en/data/dumps.md
@@ -14,7 +14,13 @@ weight: 20
 
 ## Latest data dump
 
-**We will be deprecating this bucket soon and introducing a new service with higher quality and more up-to-date data.**
+> **Warning**
+> 
+> We will be deprecating this bucket soon and introducing a new service with higher quality and more up-to-date data.
+> The new data is accessible via GCS on these links: 
+>   - **Raw data** at `gs://fil-mainnet-archive/raw/`. This folder contains data as [it was exported by `lily-archiver`](https://github.com/filecoin-project/lily-archiver/). Might contain duplicated and missing days.
+>   - **Parquet** at `gs://fil-mainnet-archive/parquet/`. Daily partitioned parquet files. Eventually should be the source of truth as we are deduplicating and correcting any other potential errors.
+>   - **CSVs** at `gs://fil-mainnet-archive/csv/`. Daily partitioned gzip compressed CSV files. They contain the same data than the parquet files.
 
 The following is a snapshot of what is available as of 2023-01-06:
 


### PR DESCRIPTION
This PR expands the warning adding links to the GCS folders we're using to host the new Lily data.